### PR TITLE
updates << to be add_candy

### DIFF
--- a/warmup/spec/trick_or_treater_spec.rb
+++ b/warmup/spec/trick_or_treater_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe TrickOrTreater do
 
   xit 'can get candies' do
     trick_or_treater = TrickOrTreater.new(Costume.new('Spaceship Mechanic'))
-    trick_or_treater.bag << Candy.new('Gummy bears')
+    trick_or_treater.bag.add_candy Candy.new('Gummy bears')
 
     expect(trick_or_treater.has_candy?).to be true
   end


### PR DESCRIPTION
On line 34 in the **trick_or_treater_spec.rb** file, `trick_or_treater.bag << Candy.new('Gummy bears')` has been changed to `trick_or_treater.bag.add_candy Candy.new('Gummy bears')`. 

We always had students change this in class, so this PR just makes the change permanent. Although adding a shovel method to the `Bag` class is doable, it is out of place in the current spec and the following tests make use of a `#add_candy` method, so the assumption is that the inclusion of the shovel operator here is a mistake.